### PR TITLE
Improvements to "Fit" button

### DIFF
--- a/DeepNestSharp.Domain/ViewModels/PreviewViewModel.cs
+++ b/DeepNestSharp.Domain/ViewModels/PreviewViewModel.cs
@@ -19,6 +19,10 @@
     private IPointXY dragOffset;
     private IPointXY dragStart;
     private double canvasScale = 1;
+    private double canvasScaleMin = 0.5;
+    private double canvasScaleMax = 10;
+    private double gridWidth = 400;
+    private double gridHeight = 400;
     private IPointXY viewport;
     private RelayCommand fitAllCommand = null;
     private IPointXY actual;
@@ -154,9 +158,13 @@
       }
     }
 
-    public double CanvasScaleMax => 10;
+    public double CanvasScaleMax => this.canvasScaleMax;
 
-    public double CanvasScaleMin => 0.5;
+    public double CanvasScaleMin => this.canvasScaleMin;
+
+    public double GridWidth => this.gridWidth;
+
+    public double GridHeight => this.gridHeight;
 
     public IPointXY LowerBound
     {
@@ -325,21 +333,26 @@
 
     private void OnFitAll()
     {
-      // Actual.X: The width, in pixels, of the preview graphics window
-      // Actual.Y: The height, in pixels, of the preview graphics window
-      // ZoomDrawingContext.Extremum(...): seems to calculate extrema of the previewed object in the physical units represented in the dxf file
-      double minx = this.ZoomDrawingContext.Extremum(MinMax.Min, XY.X);
-      double maxx = this.ZoomDrawingContext.Extremum(MinMax.Max, XY.X);
-      double miny = this.ZoomDrawingContext.Extremum(MinMax.Min, XY.Y);
-      double maxy = this.ZoomDrawingContext.Extremum(MinMax.Max, XY.Y);
-      double actualX = this.Actual.X;
-      double actualY = this.Actual.Y;
-      double scaleX = actualX / (maxx - minx);
-      double scaleY = actualX / (maxy - miny);
+      // These are "magic numbers" until we figure out how to access their values programmatically
+      double horizontalScrollBarWidth = 20;
+      double verticalScrollBarWidth = 20;
+      double fieldWidth = this.Actual.X - verticalScrollBarWidth;
+      double fieldHeight = this.Actual.Y - horizontalScrollBarWidth;
+
+      //// Fits the grid on which the canvas is drawn inside the scrollviewer without the CANVAS extending past edges (grid may extend past in certain scenarios).
+      //if (this.ZoomDrawingContext.Height / this.ZoomDrawingContext.Width >= fieldHeight / fieldWidth)
+      //{
+      //  this.CanvasScale = fieldHeight / this.GridHeight;
+      //}
+      //else
+      //{
+      //  this.CanvasScale = fieldWidth / this.GridWidth;
+      //}
+
+      // Fits the grid on which the canvas is drawn inside the scrollviewer without the GRID extending past edges.
+      double scaleX = fieldWidth / this.GridWidth;
+      double scaleY = fieldHeight / this.GridHeight;
       this.CanvasScale = Math.Min(scaleX, scaleY);
-      //this.CanvasScale = Math.Min(
-      //  this.Actual?.X / (this.ZoomDrawingContext.Extremum(MinMax.Max, XY.X) - this.ZoomDrawingContext.Extremum(MinMax.Min, XY.X)) ?? 5,
-      //  this.Actual?.Y / (this.ZoomDrawingContext.Extremum(MinMax.Max, XY.Y) - this.ZoomDrawingContext.Extremum(MinMax.Min, XY.Y)) ?? 5);
     }
 
     private void PreviewViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/DeepNestSharp.Domain/ViewModels/PreviewViewModel.cs
+++ b/DeepNestSharp.Domain/ViewModels/PreviewViewModel.cs
@@ -328,9 +328,18 @@
       // Actual.X: The width, in pixels, of the preview graphics window
       // Actual.Y: The height, in pixels, of the preview graphics window
       // ZoomDrawingContext.Extremum(...): seems to calculate extrema of the previewed object in the physical units represented in the dxf file
-      this.CanvasScale = Math.Min(
-        this.Actual?.X / (this.ZoomDrawingContext.Extremum(MinMax.Max, XY.X) - this.ZoomDrawingContext.Extremum(MinMax.Min, XY.X)) ?? 5,
-        this.Actual?.Y / (this.ZoomDrawingContext.Extremum(MinMax.Max, XY.Y) - this.ZoomDrawingContext.Extremum(MinMax.Min, XY.Y)) ?? 5);
+      double minx = this.ZoomDrawingContext.Extremum(MinMax.Min, XY.X);
+      double maxx = this.ZoomDrawingContext.Extremum(MinMax.Max, XY.X);
+      double miny = this.ZoomDrawingContext.Extremum(MinMax.Min, XY.Y);
+      double maxy = this.ZoomDrawingContext.Extremum(MinMax.Max, XY.Y);
+      double actualX = this.Actual.X;
+      double actualY = this.Actual.Y;
+      double scaleX = actualX / (maxx - minx);
+      double scaleY = actualX / (maxy - miny);
+      this.CanvasScale = Math.Min(scaleX, scaleY);
+      //this.CanvasScale = Math.Min(
+      //  this.Actual?.X / (this.ZoomDrawingContext.Extremum(MinMax.Max, XY.X) - this.ZoomDrawingContext.Extremum(MinMax.Min, XY.X)) ?? 5,
+      //  this.Actual?.Y / (this.ZoomDrawingContext.Extremum(MinMax.Max, XY.Y) - this.ZoomDrawingContext.Extremum(MinMax.Min, XY.Y)) ?? 5);
     }
 
     private void PreviewViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/DeepNestSharp/Ui/UserControls/DrawingContextBoundZoomPreview.xaml
+++ b/DeepNestSharp/Ui/UserControls/DrawingContextBoundZoomPreview.xaml
@@ -25,9 +25,19 @@
       <RowDefinition Height="*" />
     </Grid.RowDefinitions>
     <Button Grid.Column="0" Grid.Row="0" Content=" Fit " Command="{Binding FitAllCommand}" />
-    <Slider Grid.Column="0" Grid.Row="1" Orientation="Vertical" HorizontalAlignment="Center" Minimum="1" x:Name="slider" Value="{Binding CanvasScale}" />
+    <Slider Grid.Column="0"
+            Grid.Row="1"
+            Orientation="Vertical"
+            HorizontalAlignment="Center"
+            Minimum="{Binding CanvasScaleMin}"
+            Maximum="{Binding CanvasScaleMax}"
+            x:Name="slider"
+            Value="{Binding CanvasScale}" />
     <ScrollViewer Name="scrollViewer" Grid.Column="1" Grid.Row="0" Grid.RowSpan="2" VerticalScrollBarVisibility="Visible" HorizontalScrollBarVisibility="Visible">
-      <Grid Name="grid" Width="400" Height="400" RenderTransformOrigin="0.5,0.5">
+      <Grid Name="grid"
+            Width="{Binding GridWidth}"
+            Height="{Binding GridHeight}"
+            RenderTransformOrigin="0.5,0.5">
         <Grid.LayoutTransform>
           <TransformGroup>
             <ScaleTransform x:Name="scaleTransform"/>

--- a/DeepNestSharp/Ui/UserControls/DrawingContextBoundZoomPreview.xaml.cs
+++ b/DeepNestSharp/Ui/UserControls/DrawingContextBoundZoomPreview.xaml.cs
@@ -23,6 +23,8 @@
     private ObservablePartPlacement? capturePartPlacement;
     private System.Windows.Shapes.Polygon? capturePolygon;
 
+    private double pixelsPerUnit;
+
     public DrawingContextBoundZoomPreview()
     {
       this.InitializeComponent();
@@ -36,6 +38,12 @@
       this.scrollViewer.MouseMove += this.OnMouseMove;
 
       this.slider.ValueChanged += this.OnSliderValueChanged;
+    }
+
+    private double PixelsPerUnit
+    {
+      get => this.pixelsPerUnit;
+      set => this.pixelsPerUnit = value;
     }
 
     private static bool IsScrollModifierPressed
@@ -124,6 +132,7 @@
         BringToFront(canvas, polygon);
         if (IsDragModifierPressed && vm.MainViewModel.ActiveDocument is SheetPlacementViewModel)
         {
+          this.PixelsPerUnit = Math.Max(canvas.ActualWidth / vm.GridWidth, canvas.ActualHeight / vm.GridHeight);
           vm.DragStart = new SvgPoint(mousePos.X, mousePos.Y);
           this.scrollViewer.Cursor = Cursors.Hand;
           this.partPlacementStartPos = new Point(vm.SelectedPartPlacement.X, vm.SelectedPartPlacement.Y);
@@ -251,7 +260,7 @@
           if (IsDragModifierPressed)
           {
             IPointXY dragStart = vm.DragStart;
-            vm.DragOffset = new SvgPoint((vm.MousePosition.X - dragStart.X) / this.scaleTransform.ScaleX, (vm.MousePosition.Y - dragStart.Y) / this.scaleTransform.ScaleY);
+            vm.DragOffset = new SvgPoint(this.PixelsPerUnit * (vm.MousePosition.X - dragStart.X) / this.scaleTransform.ScaleX, this.PixelsPerUnit * (vm.MousePosition.Y - dragStart.Y) / this.scaleTransform.ScaleY);
 
             // System.Diagnostics.Debug.Print($"DragOffset={vm.DragOffset:N2}");
             this.capturePartPlacement.X = this.partPlacementStartPos.X + vm.DragOffset.X;
@@ -280,7 +289,7 @@
       if (vm.IsDragging && IsDragModifierPressed && vm.DragStart != null)
       {
         IPointXY dragStart = vm.DragStart;
-        vm.DragOffset = new SvgPoint((vm.MousePosition.X - dragStart.X) / this.scaleTransform.ScaleX, (vm.MousePosition.Y - dragStart.Y) / this.scaleTransform.ScaleY);
+        vm.DragOffset = new SvgPoint(this.PixelsPerUnit * (vm.MousePosition.X - dragStart.X) / this.scaleTransform.ScaleX, this.PixelsPerUnit * (vm.MousePosition.Y - dragStart.Y) / this.scaleTransform.ScaleY);
         System.Diagnostics.Debug.Print($"Drag commit@{vm.DragOffset.X:N2},{vm.DragOffset.Y:N2}");
         if (this.capturePartPlacement != null)
         {

--- a/DeepNestSharp/Ui/UserControls/HorizontalScrollHandler.cs
+++ b/DeepNestSharp/Ui/UserControls/HorizontalScrollHandler.cs
@@ -22,7 +22,7 @@
             var divider = Constants.HorizontalScrollDivider;
             var offset = scrollViewer.HorizontalOffset;
             var delta = e.Delta;
-            offset += delta / divider;
+            offset -= delta / divider;
             scrollViewer.ScrollToHorizontalOffset(offset);
             e.Handled = true;
           }


### PR DESCRIPTION
Pressing "Fit" now correctly calculates the CanvasScale needed to fit the 400 x 400 pixel grid that the canvas is plotted on into the graphics area without any part of the polygon (or the grid on which it is plotted) extending past the edges.